### PR TITLE
Fixed broken dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ license: MIT
 
 dependencies:
   kiwi:
-    github: greyblake/crystal-kiwi
+    github: crystal-community/kiwi
     version: ~> 0.1.0
 
 development_dependencies:


### PR DESCRIPTION
Kiwi is no longer located in the same place. I've linked it to the correct place.